### PR TITLE
Fixing issues chapter 1-2

### DIFF
--- a/chapter-1-basics.md
+++ b/chapter-1-basics.md
@@ -66,7 +66,7 @@ Now, that you have a running MORYX instance, you need to create some databases.
 To skip the UI here and speed things up, you'll use the MORYX CLI again.
 
 While the application is still running, `moryx exec post-setup` will create empty 
-databases and restart dependent modules. Execute this command twice. If your application runs on a different
+databases and restart dependent modules. If your application runs on a different
 host than `https://localhost:5000`, you can specify that by the `--endpoint <URL>`
 option.
 
@@ -101,7 +101,7 @@ From the details above, the `GraphitePencilType` needs
 * a hardness property
   
 You will find the `GraphitePencilType` among all other `<Product>Types` in the
-`Moryx.PencilFactory` package within the `Products` folder.
+`PencilFactory` package within the `Products` folder.
 
 For properties to be shown on the UI, add the [EntrySerialize](https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/dev/docs/articles/Core/Serialization/EntryConvert.md#entryserialize-attribute)
 attribute. For properties to be saved in the database, use the [DataMember](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.datamemberattribute?view=net-7.0) attribute.
@@ -185,7 +185,7 @@ Now you have your products `100001-00 Brown Pencil GP-1B` and
 `100002-00 Green Pencil GP-HB` and a resource that can produce those products. 
 The next challenge is to let your resource produce the pencils? So far there is 
 no script that describes how the pencils are produced by the resources. All that 
-exist currently are pencils and resources. The next step now is **Recipe** and 
+exist currently are pencils and resources. The next step now is to create a **Recipe** and a 
 [Workplan](https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/dev/docs/articles/Processing/Workplans.md). 
 
 
@@ -219,7 +219,7 @@ Based on these requirements
 
 ### Add worker support
 
-The `AssemblingCell`, you will find it in `Moryx.Resources.PencilFactory`, 
+The `AssemblingCell`, you will find it in `PencilFactory.Resources`, 
 already has an instructor.
 
 ``` cs
@@ -483,7 +483,7 @@ The application depends on MORYX modules, that are licensed. But no worries:
 They ship with developer licenses, that need to be activated:
 
 * Open [*CodeMeter Control Center*](https://www.phoenixcontact.com/de-de/produkte/programmier-software-plcnext-engineer-1046008), 
-  that you should have installed beforehand 
+  that you should have installed beforehand through the [PHOENIX CONTACT Activation Wizard](https://www.phoenixcontact.com/de-de/produkte/programmier-software-plcnext-engineer-1046008)
 * Drag & Drop the `.WibuCmRau` files onto it
   
 ![Activate developer licenses](./chapter-1/drag-licenses.png)

--- a/chapter-2-drivers.md
+++ b/chapter-2-drivers.md
@@ -18,7 +18,7 @@ Use the CLI to add the Colorizing step to the project.
 ```
 moryx add step Colorizing
 ```
-Now, in order to use simulation, add the package `Moryx.Drivers.Simulation` to the project `Moryx.Resources.PencilFactory`.
+Now, in order to use simulation, add the package `Moryx.Drivers.Simulation` to the project `PencilFactory.Resources`.
 
 The ColorizingCell is using a protocol, where it can read and write variables on the physical cell.
 
@@ -44,7 +44,7 @@ public class Colorizing : Cell
 }
 ```
 
-In order to recognize, when an input changed, subsribe to that in  `OnInitialize` and when the driver is set. If you don't also subscribe to the event in the setter of the driver, you always have to restart the system after changing the driver of a cell.
+In order to recognize, when an input changed, subscribe to that in  `OnInitialize` and when the driver is set. If you don't also subscribe to the event in the setter of the driver, you always have to restart the system after changing the driver of a cell.
 
 ```cs
 private IInOutDriver<bool,bool> _driver;
@@ -79,7 +79,7 @@ In the method `OnInputChanged` you will check, if the value of `Ready` changed. 
 ```cs
 private void OnInputChanged(object sender, InputChangedEventArgs e)
 {
-    if (e.Key.Equals(Ready) && _driver.Input[Ready] && !(_currentSession is ActivityStart))
+    if (e.Key.Equals(ReadyToWork) && _driver.Input[ReadyToWork] && !(_currentSession is ActivityStart))
     {
         var rtw = Session.StartSession(ActivityClassification.Production, ReadyToWorkType.Pull);
         _currentSession = rtw;
@@ -90,7 +90,7 @@ private void OnInputChanged(object sender, InputChangedEventArgs e)
 }
 ```
 
-If the changed input is `ProcessResult`, read the result from the input and publish it as `ActivityCompleted`. Also set the input `ProcessStart` back to false, so that the physical cell is able to detect when to start the next process. If don't reset the value of `ProcessStart`, the physical cell is not able to recognize the specific moment an activity should start. Some physical cells also only recognize rising or falling edges. Constant values would trigger nothing.
+If the changed input is `ProcessResult`, read the result from the input and publish it as `ActivityCompleted`. Also set the input `ProcessStart` back to false, so that the physical cell is able to detect when to start the next process. If you don't reset the value of `ProcessStart`, the physical cell is not able to recognize the specific moment an activity should start. Some physical cells also only recognize rising or falling edges. Constant values would trigger nothing.
 
 ```cs
 private void OnInputChanged(object sender, InputChangedEventArgs e)
@@ -144,7 +144,7 @@ public override IEnumerable<Session> ControlSystemAttached()
 }
 ```
 
-Now you have to implement the driver. Create a new driver `SimulatedColorizingDriver` in the project `Moryx.Resources.PencilFactory`, which is derived from `SimulatedInOutDriver<bool, bool>` and add the constants for the variable names. 
+Now you have to implement the driver. Create a new driver `SimulatedColorizingDriver` in the project `PencilFactory.Resources`, which is derived from `SimulatedInOutDriver<bool, bool>` and add the constants for the variable names. 
 
 ```cs
 [ResourceRegistration]
@@ -180,7 +180,7 @@ protected override void OnOutputSet(object sender, string key)
 {
     if (key == ProcessStart)
     {
-        SimulatedInput.Values[Ready] = false;
+        SimulatedInput.Values[ReadyToWork] = false;
         if (SimulatedOutput.Values[ProcessStart])
             SimulatedState = SimulationState.Executing;
         else


### PR DESCRIPTION
changing package naming scheme to match the template 
Clarifying that the ControlCenter is installed by the Activation Wizard, which could easily lead to confusion before
fix typos