### PR TITLE
Fix some issues with the ADP

### DIFF
--- a/chapter-2-drivers.md
+++ b/chapter-2-drivers.md
@@ -32,7 +32,7 @@ The ColorizingCell is using a protocol, where it can read and write variables on
 3. When the cell receives an activity, set the output `ProcessStart` to `true`.
 4. Read the result from the input `ProcessResult`.
 
-For a protocol like that the `IInOutDriver` makes the most sense. Open the ColorizingCell and replace the already generated `IMessageDriver` by an `IInOutDriver`. Also add constants for the names of the variables to read and write.
+For a protocol like that the `IInOutDriver` makes the most sense. Open the ColorizingCell. It should already contain an `IInOutDriver`. Also add constants for the names of the variables to read and write.
 
 ```cs
 [ResourceRegistration]
@@ -49,14 +49,14 @@ public class ColorizingCell : Cell, IStateContext
 }
 ```
 
-In order to recognize, when an input changes, subscribe to that in `OnInitializeAsync` and when the driver is set. If you don't also subscribe to the event in the setter of the driver, you will always have to restart the system after changing the driver of a cell.
+In order to recognize, when an input changes, subscribe to that in when the driver is set. If you don't also subscribe to the event in the setter of the driver, you will always have to restart the system after changing the driver of a cell.
 Adjust the Driver variable and functions to match the following.
 
 ```cs
 [ResourceReference(ResourceRelationType.Driver)]
 public IInOutDriver Driver
 {
-    get => field
+    get => field;
     set
     {
         if (field?.Input != null)
@@ -74,17 +74,6 @@ public IInOutDriver Driver
 }
 ```
 
-```cs
-protected override void OnInitializeAsync()
-{
-    ...
-
-    if (Driver?.Input != null)
-    {
-        Driver.Input.InputChanged += OnInputChanged;
-    }
-}
-```
 
 In the method `OnInputChanged` you will check, if the value of `Ready` has changed. If it is true, send a `ReadyToWork` to the ProcessEngine.
 Replace the contents of the function with the following two code segments.

--- a/chapter-3-basics-II.md
+++ b/chapter-3-basics-II.md
@@ -92,7 +92,7 @@ public class ColorizingParameters : VisualInstructionParameters
 {
     public PencilColor Color { get; set; }
 
-    protected override void Populate(IProcess process, Parameters instance)
+    protected override void Populate(Process process, Parameters instance)
     {
         base.Populate(process,instance);
 


### PR DESCRIPTION

### Summary

Addressed issues:
1) Missing semicolon
2) Don't register event twice. In EventHandler and OnInitializeAsync -> Alternative would be to unregister first in OnInitialize or check if we are already initialized in setter
3) Populate takes Process instead of IProcess

There are other issues that might be worth addressing.
For instance it might be interesting to only publish a ReadyToWork in the ColorizingCell, when both the ProcessEngine is attached and the Driver is set and in a Running state.

I didn't change them yet, because I am not sure if this is beyond the scope of the chapter.

### Linked Issues

<!-- 
Link to any related issues using GitHub keywords (e.g., Fixes #123, Closes #456).
-->

### Relevant logs and/or screenshots

<!-- 
Paste any relevant logs. Please use code blocks (```) to format console output, logs, and code.
-->

### Breaking Changes

<!-- 
Does this PR introduce any breaking changes? If yes, describe them.
-->

### Checklist for Submitter

- [x] I have tested these changes locally
- [x] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [x] Merge request is well described
- [x] Critical sections are *documented in code*
- [x] *Tests* are extended
- [x] *Documentation* is created / updated
- [x] Running in test environment
- [x] Ports to other maintained versions are created

**Clean code**

- [x] *All* unused references are removed
- [x] Clean code rules are respected with passion (naming, ...)
- [x] Avoid *copy and pasted* code snippets