### PR TITLE
Add OSS simulation tutorial reference to documentation

### DIFF
--- a/chapter-1-basics.md
+++ b/chapter-1-basics.md
@@ -48,7 +48,8 @@ in the following command:
 moryx new PencilFactory --steps Assembling --products GraphitePencil
 ```
 
-> **Note** This training uses a simplified application template that is tailored to this scenario. It is provided by the --branch parameter here.
+> [!NOTE]
+> This training uses a simplified application template that is tailored to this scenario. It is provided by the --branch parameter here.
 > For real world applications you would probably omit --branch for a more advanced default setup or customize it to your needs (see [Moryx.Cli README](https://www.nuget.org/packages/Moryx.Cli#readme-body-tab) or moryx --help for more information).
 
 This should not only leave you with a solution `PencilFactory.sln` inside
@@ -59,7 +60,8 @@ That means, you can directly open it in Visual Studio and dig into it.
 
 Run the application (press `F5`).
 
-> **Note** Starting it for the first time will restore NuGet packages.That can
+> [!NOTE]
+> Starting it for the first time will restore NuGet packages.That can
 > take a few minutes.
 
 ![Application dashboard](./chapter-1/HomePageOfPencilApp.PNG)
@@ -92,7 +94,8 @@ Let's take a look at the composition of the pencil *Pencilla Inc.* produces.
 * The pencil has a color (green or brown).
 * Graphite can be in different degrees of hardness, in this scenario *2B*, *B* and *HB*.
 
-> **Note** that, when defining the hardness of pencils, the number (degree) is
+> [!NOTE]
+> When defining the hardness of pencils, the number (degree) is
 > put first (2B, 2H, etc.). Since this can't be represented in code, it is
 > switched for names, while for everything else the official format is used. If
 > you are interested, you will find more about [grading and classification here](https://en.wikipedia.org/wiki/Pencil#Grading_and_classification).
@@ -147,7 +150,8 @@ To create a product, you need to run the application now and head to the
 Click on the plus button to open the 'Product Importer' menu. This title may
 sound a bit confusing, but it lets you add new products.
 
-> **Note** The naming here comes from the fact, that you wouldn't necessarily add
+> [!NOTE]
+> The naming here comes from the fact, that you wouldn't necessarily add
 > products here, but 'import' them from other systems.
 
 ![New product](./chapter-1/create-product.png)
@@ -245,7 +249,8 @@ instructions to a worker. So the following resources are needed:
 You will set up these in MORYX within the *Resources UI* by clicking the "+"
 button and selecting the required cell.
 
-> **Note** Make sure to deselect all cells before adding more, so that they will
+> [!NOTE]
+> Make sure to deselect all cells before adding more, so that they will
 > be added to the root level and not as children of other resources. Even though,
 > that wouldn't do any harm.
 

--- a/chapter-2-drivers.md
+++ b/chapter-2-drivers.md
@@ -13,6 +13,14 @@ Common interfaces for drivers are `IMessageDriver<TMessage>` and `IInOutDriver`.
 * The `IMessageDriver<TMessage>` is used for message based protocols. The driver is able to send and receive messages. When a new message is received, an event gets invoked. A typical protocol would be MQTT.
 * The `IInOutDriver` can read and write variables on a server. A typical protocol is OPC UA.
 
+### Additional Documentation: Simulation
+
+If you want to learn more about how simulation works in MORYX or how simulated drivers interact with cells, the full open‑source tutorial is available here:
+
+🔗 https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/dev/docs/tutorials/how-to-simulate-my-production.md
+
+This guide explains the architecture behind the simulation module, the states of a simulation driver, and how `ISimulationDriver` can be implemented to emulate hardware behavior. It extends the concepts shown in this chapter with more background and advanced examples.
+
 ## Simulated InOutDriver
 
 You will start with the ColorizingCell. Since the cell isn't finished yet, the manufacturer wants you to simulate the communication first.
@@ -221,3 +229,5 @@ Then create a new workplan containing both steps and add it through a recipe to 
 ![Complete workplan](./chapter-2/CompleteWorkplan.png)
 
 Now you should be able to start a new production.
+
+

--- a/chapter-2-drivers.md
+++ b/chapter-2-drivers.md
@@ -8,20 +8,19 @@ For the cell to communicate with the hardware a [Driver](https://github.com/PHOE
 In here the communication is encapsulated.
 
 As there are many different ways to communicate, there are also many different implementations of drivers.
-Common interfaces for drivers are `IMessageDriver<TMessage>` and `IInOutDriver`.
+Common interfaces for drivers are `IMessageDriver` and `IInOutDriver`.
 
-* The `IMessageDriver<TMessage>` is used for message based protocols. The driver is able to send and receive messages. When a new message is received, an event gets invoked. A typical protocol would be MQTT.
+* The `IMessageDriver` is used for message based protocols. The driver is able to send and receive messages. When a new message is received, an event gets invoked. A typical protocol would be MQTT.
 * The `IInOutDriver` can read and write variables on a server. A typical protocol is OPC UA.
 
-### Additional Documentation: Simulation
-
-If you want to learn more about how simulation works in MORYX or how simulated drivers interact with cells, the full open‑source tutorial is available here:
-
-🔗 https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/dev/docs/tutorials/how-to-simulate-my-production.md
-
-This guide explains the architecture behind the simulation module, the states of a simulation driver, and how `ISimulationDriver` can be implemented to emulate hardware behavior. It extends the concepts shown in this chapter with more background and advanced examples.
-
 ## Simulated InOutDriver
+
+> [!NOTE]  
+> If you want to learn more about how simulation works in MORYX or how simulated drivers interact with cells, the full open‑source tutorial is available here:  
+> 🔗 https://github.com/PHOENIXCONTACT/MORYX-Framework/blob/dev/docs/tutorials/how-to-simulate-my-production.md  
+> This guide explains the architecture behind the simulation module, the states of a simulation driver, and how `ISimulationDriver` can be implemented to emulate hardware behavior. 
+> It extends the concepts shown in this chapter with more background and advanced examples.
+
 
 You will start with the ColorizingCell. Since the cell isn't finished yet, the manufacturer wants you to simulate the communication first.
 


### PR DESCRIPTION
This PR adds a reference to the newly available OSS simulation tutorial inside the driver chapter of the Application Developer Training. The link points to the official MORYX Framework documentation and provides additional background about how simulation drivers work, how ISimulationDriver is structured, and how simulated hardware behavior integrates with cells.